### PR TITLE
feat: blinking press start

### DIFF
--- a/rainbowriders.p8
+++ b/rainbowriders.p8
@@ -54,6 +54,57 @@ INDIGO = 13
 PINK = 14
 PEACH = 15
 
+-- A collection of special effects that are easy to use
+-- This is a factory function that returns an object with special effects
+function SpecialEffect ()
+    local interval = 0
+
+    -- a function that iterates the interval
+    local iterate = function ()
+        interval = interval + 1
+        if interval > 1000 then
+            interval = 0
+        end
+    end
+
+    -- Example Usage:
+    -- local effect = SpecialEffect() -- store this globally
+    -- effect.cycle({RED, ORANGE, YELLOW, GREEN, BLUE, INDIGO, DARK_PURPLE}, 10, function (color, index)
+    --     print("color: " .. color .. " index: " .. index)
+    -- end)
+    local cycle = function (list, rate, callback)
+        -- iterate the interval
+        iterate()
+        -- return the item in the list based on the interval
+        local item = list[flr(interval / rate) % #list + 1]
+        -- call the callback with the item and the index
+        callback(item, flr(interval / rate) % #list + 1)
+    end
+
+    -- Example Usage:
+    -- local effect2 = SpecialEffect() -- store this globally
+    -- effect2.blink(10, function (on_off, index)
+    --     if on_off == 0 then
+    --         print("off")
+    --     else
+    --         print("on")
+    --     end
+    -- end)
+    local blink = function (rate, callback)
+        -- iterate the interval
+        iterate()
+        -- return the item in the list based on the interval
+        local on_off = flr(interval / rate) % 2
+        -- call the callback with the item and the index
+        callback(on_off, flr(interval / rate) % 2)
+    end
+
+    return {
+        cycle = cycle,
+        blink = blink
+    }
+end
+
 -- @EXPERIMENTAL FEATURE: Jelly's Rainbow Progression (aka rbp_)
 -- How it works: As the score increases, players will accumulate rainbow colors.
 -- The colors will be displayed as a trail behind the player.
@@ -345,6 +396,7 @@ function draw_gameover_screen()
     -- they will be reset at the start of a new game
 end
 
+press_start_blinker = SpecialEffect().blink
 function draw_title_screen()
     local color = rainbow_colors[color_index]
     for i = 1, 6 do
@@ -354,7 +406,11 @@ function draw_title_screen()
     end
 
     print("rainbow riders", 33, 53, color)
-    print("press start", 39, 86, 7)
+    press_start_blinker(15, function (on_off, index)
+        if on_off == 0 then
+            print("press start", 39, 86, 7)
+        end
+    end)
     print("(c) copyright 1977 - dads' games", 0, 120, 1)
 end
 


### PR DESCRIPTION
![effects-factoriy](https://github.com/user-attachments/assets/23cee8db-3d69-412e-9fe4-fb69d4888ebd)

# Add Special Effects Factory and Blinking "Press Start" Text

This PR introduces a new Special Effects Factory and implements a blinking "Press Start" text on the title screen.

## Changes

### 1. Special Effects Factory

- Added a `SpecialEffect()` factory function that returns an object with special effects capabilities.
- Implemented two main effects:
  - `cycle`: Allows cycling through a list of items (e.g., colors) at a specified rate.
  - `blink`: Creates a blinking effect at a specified rate.

### 2. Blinking "Press Start" Text

- Utilized the new `SpecialEffect().blink` function to create a blinking effect for the "Press Start" text on the title screen.
- Implemented in the `draw_title_screen` function to toggle the visibility of the "press start" text.

### 3. Documentation

- Added comments explaining how to use the `SpecialEffect` factory and its methods.

## Code Sample
```lua
press_start_blinker = SpecialEffect().blink
-- ... (in draw_title_screen function)
press_start_blinker(15, function (on_off, index)
    if on_off == 0 then
        print("press start", 39, 86, 7)
    end
end)
```

## Impact

These changes enhance the visual appeal of the game's title screen and provide a reusable framework for adding more special effects throughout the game in the future.