### PR TITLE
feat: adds a 3 second obstacle grace period

### DIFF
--- a/src/screens/character_select.lua
+++ b/src/screens/character_select.lua
@@ -17,7 +17,7 @@ function CharacterSelect(state)
         -- Confirm selection and start game
         if btnp(4) then
             player.sprite = selected_char
-            state.screen = screens.game
+            state.screen = Game(state)
             sfx(59) -- character selected sfx
             music(26, 0, 0)
         end

--- a/src/screens/game.lua
+++ b/src/screens/game.lua
@@ -14,8 +14,14 @@ function Game (state)
     local background_x = 0
     local background_n = 128 * 8 -- number of tiles wide for the background in the map * 8
     local background_y = 96--84
+    local grace_period = 30 * 3 -- 3 seconds
+    local grace_period_counter = 0
 
     local clouds = CloudSystem()
+
+    function is_grace_period ()
+        return grace_period_counter < grace_period
+    end
 
     function draw_stretched_sprite(sprite, x, y, dy)
         local stretch_factor = 1 + abs(dy) * 0.1
@@ -31,8 +37,14 @@ function Game (state)
     end
 
     function game_controller ()
+
         if not game_over then
             clouds.update()
+
+            -- Increment grace period counter
+            if is_grace_period() then
+                grace_period_counter = grace_period_counter + 1
+            end
 
             -- Timer update
             timer_frame_counter = timer_frame_counter + 1
@@ -73,7 +85,7 @@ function Game (state)
 
             -- Spawn obstacles
             spawn_timer = spawn_timer + 1
-            if spawn_timer > spawn_interval + rnd(180) then
+            if not is_grace_period() and spawn_timer > spawn_interval + rnd(180) then
                 spawn_timer = 0
                 if not state.debug_mode then
                     sprite_obstacle = flr(rnd(12)) + 192


### PR DESCRIPTION
This adds a 3 second grace period at the beginning of each run through so players have a moment to acclimate to game play.

This was introduced as sometimes obstacles would spawn directly in front of players immediately when game loads.