### PR TITLE
feat: reduces the game over screen delay

### DIFF
--- a/src/screens/game_over.lua
+++ b/src/screens/game_over.lua
@@ -1,7 +1,7 @@
 function GameOver (state)
     local game_over_timer = 0
     local game_over_timer = 0
-    local game_over_delay = 180 -- 1 second (60 frames per second)
+    local game_over_delay = 60 -- 1 second (60 frames per second)
 
     function game_over_controller ()
         -- Increment game over timer


### PR DESCRIPTION
score screen felt too long. we can introduce a skip score screen with key press feature if we want to lengthen duration. shortened timer for now.